### PR TITLE
add content for first zoom poll in beginner class

### DIFF
--- a/courses/beginner/02.md
+++ b/courses/beginner/02.md
@@ -18,8 +18,7 @@ _Note that InSpec is not the only validation solution, but the one preferred at 
 :::
 
 ::: details Is your Codespace environment set up successfully?
-To check, run `./verify-lab.sh`.
-This class will have hands-on activities. We recommend that you use the provided class [development lab environment](https://github.com/mitre/saf-training-lab-environment) to participate in the hands-on activities. 
+This class will have hands-on activities. We recommend that you use the provided class [development lab environment](https://github.com/mitre/saf-training-lab-environment) to participate in the hands-on activities. All you need is to login with a [GitHub](https://github.com/signup) account (which you can make for free), and follow the directions in the [README.md](https://github.com/mitre/saf-training-lab-environment#readme). To verify that your environment is setup, run `./verify-lab.sh`.
 :::
 
 ## What is an InSpec Profile?

--- a/courses/beginner/02.md
+++ b/courses/beginner/02.md
@@ -6,6 +6,22 @@ author: Aaron Lippold
 headerDepth: 3
 ---
 
+### Check-In
+::: details  Have you used InSpec before?
+There is no right or wrong answer. If this is your first time using InSpec, welcome! If you have used it before, welcome back. If you want more information on the basics of Ruby (InSpec is built on Ruby), take a look at the Ruby materials linked on the [home page](../../).
+:::
+
+::: details Which goal of the MITRE Security Automation Framework (SAF) is supported by InSpec?
+InSpec is used in the [Validate pillar](https://saf.mitre.org/#/validate). InSpec is used to do security validation.
+
+_Note that InSpec is not the only validation solution, but the one preferred at the SAF. You are not required to use InSpec to use the rest of the SAF nor are you required to use the rest of the SAF to use InSpec._
+:::
+
+::: details Is your Codespace environment set up successfully?
+To check, run `./verify-lab.sh`.
+This class will have hands-on activities. We recommend that you use the provided class [development lab environment](https://github.com/mitre/saf-training-lab-environment) to participate in the hands-on activities. 
+:::
+
 ## What is an InSpec Profile?
 
 ### InSpec Profiles  


### PR DESCRIPTION
Adding Zoom poll content to the class itself so teachers know when the polls are coming, but also so people who take the class on their own can be prompted for similar questions and have a similar experience.

There is an example of this already put in the bottom of section 3 of the beginner class. Here, I am adding one on the top of section 2.

Signed-off-by: Emily Rodriguez <ecrodriguez@mm279976-pc.lan>