### PR TITLE
Don't wget rhel8 stubs

### DIFF
--- a/src/courses/beginner/11.md
+++ b/src/courses/beginner/11.md
@@ -111,46 +111,14 @@ EXAMPLES
 
 ### How to Get the Pre-made Profile
 
-We have a pre-made profile generated with the `saf generate xccdf_benchmark2inspec_stub` command sitting on the [Resources](https://mitre.github.io/saf-training/resources/#rhel8-baseline-stubs) page for these classes. For the purposes of this class, you'll need to download it into your Codespaces library. You can do this with the `wget` shell command.
-
-::: code-tabs#shell
-
-@tab Fetching the pre-made profile with `wget`
-
-```sh
-wget https://github.com/mitre/inspec-profile-developer-course-lab-environment/raw/main/resources/rhel8-baseline-stubs.tar.gz
-```
-
-@tab Output
-
-```sh
-/workspaces/saf-training-lab-environment/rhel8-baseline-stubs (main) $ wget https://github.com/mitre/inspec-profile-developer-course-lab-environment/raw/main/resources/rhel8-baseline-stubs.tar.gz
---2023-02-09 14:51:56--  https://github.com/mitre/inspec-profile-developer-course-lab-environment/raw/main/resources/rhel8-baseline-stubs.tar.gz
-Resolving github.com (github.com)... 140.82.112.4
-Connecting to github.com (github.com)|140.82.112.4|:443... connected.
-HTTP request sent, awaiting response... 302 Found
-Location: https://raw.githubusercontent.com/mitre/inspec-profile-developer-course-lab-environment/main/resources/rhel8-baseline-stubs.tar.gz [following]
---2023-02-09 14:51:57--  https://raw.githubusercontent.com/mitre/inspec-profile-developer-course-lab-environment/main/resources/rhel8-baseline-stubs.tar.gz
-Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.111.133, ...
-Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.
-HTTP request sent, awaiting response... 200 OK
-Length: 197531 (193K) [application/octet-stream]
-Saving to: ‘rhel8-baseline-stubs.tar.gz’
-
-rhel8-baseline-stubs.tar.gz                   100%[=================================================================================================>] 192.90K  --.-KB/s    in 0.004s  
-
-2023-02-09 14:51:57 (47.0 MB/s) - ‘rhel8-baseline-stubs.tar.gz’ saved [197531/197531]
-```
-:::
-
-Once you've used `wget` to grab the compressed profile, we need to uncompress it so that we can work with the control files inside.
+We have a pre-made profile generated with the `saf generate xccdf_benchmark2inspec_stub` command sitting in the [Resources](https://mitre.github.io/saf-training/resources/#rhel8-baseline-stubs) page for these classes. For the purposes of this class, you'll need to uncompress it so that we can work with the control files inside.
 
 ::: code-tabs#shell
 
 @tab Uncompressing the profile
 
 ```sh
-tar zxvfp ./rhel8-baseline-stubs.tar.gz
+tar zxvfp ./resources/rhel8-baseline-stubs.tar.gz
 ```
 
 @tab Output

--- a/src/resources/README.md
+++ b/src/resources/README.md
@@ -88,7 +88,7 @@ saf generate:xccdf2inspec_stub -i U_RHEL_8_STIG_V1R6_Manual-xccdf.xml -r -o rhel
 ```
 This created a starter profile based of the RHEL8 STIG XCCDF Bechmark
 
-- [rhel8-baseline-stubs.tar.gz](https://github.com/mitre/inspec-profile-developer-course-lab-environment/raw/main/resources/rhel8-baseline-stubs.tar.gz)
+- [rhel8-baseline-stubs.tar.gz](https://github.com/mitre/saf-training-lab-environment/raw/main/resources/rhel8-baseline-stubs.tar.gz)
 
 ## Chef Community Slack
 


### PR DESCRIPTION
moved the rhel8 stubs tarball to the saf-training-lab-environment repo so all we need to do is untar it instead of having to wget it from the inspec-profile-developer-course-lab-environment repo which has otherwise been decommissioned