### PR TITLE
Keep behavior of mutating existing artifact in v4 of actions/upload-artifact@v4

### DIFF
--- a/src/courses/advanced/09.md
+++ b/src/courses/advanced/09.md
@@ -140,6 +140,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
+          overwrite: true
 
       # drop off the data with our dashboard
       - name: VALIDATE - Upload to Heimdall

--- a/src/courses/advanced/10.md
+++ b/src/courses/advanced/10.md
@@ -338,6 +338,7 @@ Let's run InSpec:
   uses: actions/upload-artifact@v4
   with:
     path: results/pipeline_run_attested.json
+    overwrite: true
 ```
 
 @tab `pipeline.yml` after adding validate steps
@@ -421,6 +422,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
+          overwrite: true
 ```
 
 :::
@@ -671,6 +673,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
+          overwrite: true
 
       # drop off the data with our dashboard
       - name: VALIDATE - Upload to Heimdall

--- a/src/courses/advanced/11.md
+++ b/src/courses/advanced/11.md
@@ -115,6 +115,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
+          overwrite: true
 
       # drop off the data with our dashboard
       - name: VALIDATE - Upload to Heimdall

--- a/src/courses/advanced/Appendix D - Example Pipeline for Validating an InSpec Profile.md
+++ b/src/courses/advanced/Appendix D - Example Pipeline for Validating an InSpec Profile.md
@@ -86,6 +86,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: spec/results/
+          overwrite: true
 ```
 
 The two machines are then tested by running an InSpec profile. The results are viewed and validated against a threshold to allow the pipeline to automatically pass or fail based on whether the results meet those thresholds. The SAF CLI is used to view and validate.


### PR DESCRIPTION
Missed the flag `overwrite: true` under the "VALIDATE - Save Test Result JSON" step which uses `actions/upload-artifact@v4`. Using this flag is outlined in the [official docs to migrate from V3 to V4](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#overwriting-an-artifact). 