### PR TITLE
Remove overwrite: true flag for actions/upload-artifact v4

### DIFF
--- a/src/courses/advanced/09.md
+++ b/src/courses/advanced/09.md
@@ -140,7 +140,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
-          overwrite: true
 
       # drop off the data with our dashboard
       - name: VALIDATE - Upload to Heimdall

--- a/src/courses/advanced/10.md
+++ b/src/courses/advanced/10.md
@@ -338,7 +338,6 @@ Let's run InSpec:
   uses: actions/upload-artifact@v4
   with:
     path: results/pipeline_run_attested.json
-    overwrite: true
 ```
 
 @tab `pipeline.yml` after adding validate steps
@@ -422,7 +421,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
-          overwrite: true
 ```
 
 :::
@@ -673,7 +671,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
-          overwrite: true
 
       # drop off the data with our dashboard
       - name: VALIDATE - Upload to Heimdall

--- a/src/courses/advanced/11.md
+++ b/src/courses/advanced/11.md
@@ -115,7 +115,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: results/pipeline_run_attested.json
-          overwrite: true
 
       # drop off the data with our dashboard
       - name: VALIDATE - Upload to Heimdall

--- a/src/courses/advanced/Appendix D - Example Pipeline for Validating an InSpec Profile.md
+++ b/src/courses/advanced/Appendix D - Example Pipeline for Validating an InSpec Profile.md
@@ -86,7 +86,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: spec/results/
-          overwrite: true
 ```
 
 The two machines are then tested by running an InSpec profile. The results are viewed and validated against a threshold to allow the pipeline to automatically pass or fail based on whether the results meet those thresholds. The SAF CLI is used to view and validate.


### PR DESCRIPTION
Follow-up to https://github.com/mitre/saf-training/pull/299 and https://github.com/mitre/saf-training/pull/310. This PR removes the `overwrite: true` flag for actions/upload-artifact v4 since the Markdown files refer to the same one example workflow which also doesn't depend on multiple suites.